### PR TITLE
Update setup.cfg with ax < 0.5

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -62,7 +62,7 @@ install_requires =
     scikit-learn
     scikit-optimize
     gpytorch # not sure why < 1.9.0  was necessary before, but probably fixed
-    ax-platform
+    ax-platform < 0.5
     similaritymeasures
     requests
     pyserial


### PR DESCRIPTION
Tests threw error. Should probably refactor to use latest API. Not sure if 0.5.* or 1.0.* was being installed